### PR TITLE
set TypeScript moduleResolution to "node"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "preserveConstEnums": true,
     "sourceMap": false,
     "experimentalDecorators": true,
-    "outDir": "./"
+    "outDir": "./",
+    "moduleResolution": "node"
   },
   "files": [
     "./typings/index.d.ts",


### PR DESCRIPTION
Projects using seng-boilerplate are currently unable to import modules from node. `npm run build` fails:

```
> tsc -p ./ -m system --outFile ./dist/system/seng-module.js

src/lib/Module.ts(3,39): error TS2307: Cannot find module 'foo-bar'.
``` 

Setting `moduleResolution` to `node` resolves this issue.