### PR TITLE
Update npm scripts for better use in travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,18 @@ npm install
 
 Use one of the following main scripts:
 ```sh
-npm run build   		# build this project (done on install)
+npm run build   		# build this project
+npm run generate   		# generate all artifacts (compiles ts, webpack, docs and coverage)
 npm run typings			# install .d.ts dependencies (done on install)
-npm test    			# run the tests
-npm validate			# runs validation scripts, including test, lint and doc
+npm run test-unit    	# run the unit tests
+npm run validate		# runs validation scripts, including test, lint and coverage check
 npm run lint			# run tslint on this project
 npm run doc				# generate typedoc and yuidoc documentation
 npm run typescript-npm	# just compile the typescript output used in the npm module
 ```
 
 When installing this module, it adds a pre-commit hook, that runs the `validate`
-and `build` scripts before committing, so you can be sure that everything
-checks out and all files that should be committed are generated.
+script before committing, so you can be sure that everything checks out.
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -1,29 +1,32 @@
 {
   "name": "seng-boilerplate",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Boilerplate and example project for all Seng projects",
   "main": "index.js",
   "typings": "index",
   "scripts": {
     "postinstall": "npm run typings",
-    "prepublish": "npm-run-all validate build",
+    "prepublish": "npm run build-npm",
     "typings": "typings install",
-    "test": "npm run typescript-test && karma start config/karma.conf.js --single-run --browsers PhantomJS",
-    "validate": "npm-run-all -p validate-webpack lint test -s check-coverage",
+    "test": "npm run validate",
+    "validate": "npm-run-all -p validate-webpack lint test-unit -s check-coverage",
+    "test-unit": "npm run typescript-test && karma start config/karma.conf.js --single-run --browsers PhantomJS",
     "check-coverage": "istanbul check-coverage --statement 1 --branches 1 --functions 1 --lines 1",
     "validate-webpack": "webpack-validator config/webpack.config.js",
     "lint": "tslint -c tslint.json src/**/*.ts",
     "clean": "rimraf dist lib index.js index.d.ts coverage",
     "compile": "npm-run-all typescript-npm typescript-test typescript-system typescript-es6 webpack-dist",
     "typescript-npm": "tsc -p ./ -d",
-    "typescript-test": "tsc -p test",
+    "typescript-test": "tsc -p ./test",
     "typescript-system": "tsc -p ./ -m system --outFile ./dist/system/seng-boilerplate.js",
     "typescript-es6": "tsc -p ./ -t es6 -m es6 --outDir ./dist/es6/",
     "webpack-dist": "node script/webpack.js",
     "doc": "npm-run-all -p typedoc yuidoc",
     "typedoc": "typedoc --out doc/typedoc/ src/",
     "yuidoc": "yuidoc -o doc/yuidoc/ -t ./node_modules/yuidoc-mediamonks-theme -H ./node_modules/yuidoc-mediamonks-theme/helpers/helpers.js src/",
-    "build": "npm-run-all clean compile"
+    "generate": "npm-run-all clean compile test-unit doc",
+    "build": "npm-run-all clean compile",
+    "build-npm": "npm-run-all clean test typescript-npm"
   },
   "pre-commit": [
     "validate"


### PR DESCRIPTION
- `npm test` should also do validation
- `prepublish` shouldn't run validate, but should generate coverage, and
should only compile npm artifacts
- add additional `generate` task that runs al generation scripts