### PR TITLE
Add full author information in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "pre-commit": [
     "validate"
   ],
-  "author": "Arjan van Wijk",
+  "author": "Arjan van Wijk <arjan@mediamonks.com> (https://github.com/thanarie)",
   "homepage": "https://www.mediamonks.com/",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Add email and website link to the package.json author field, because this will also be added like this by the seng-module Yeoman generator.