### PR TITLE
Resolve `ts` before `js` in webpack config

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = function()
 {
 	return {
 		resolve: {
-			extensions: ['', '.js', '.ts']
+			extensions: ['', '.ts', '.js']
 		},
 		// entry is the "main" source file we want to include/import
 		entry: [


### PR DESCRIPTION
If there are both a `.ts` and a `.js` file on disk, webpack used to load the `.js` file when it was required without extension, because `.js` was listed before `.ts` in the resolve array.
Of course, we always want the `.ts` file have priority.