### PR TITLE
Ignore `/dist` folder in git and update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ typings
 .DS_Store
 npm-debug.log
 /coverage
+/dist
 /test/*.js
 !/test/index.js
 

--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@ typings
 .DS_Store
 npm-debug.log
 /coverage
+/dist
 /test/*.js
 !/test/index.js
 
@@ -19,7 +20,6 @@ tslint.json
 karma.conf.js
 CONTRIBUTING.md
 AUTHORS.md
-/dist
 /doc
 /example
 /src

--- a/README.md
+++ b/README.md
@@ -11,18 +11,31 @@ Add a description here...
 
 ## Installation
 
+### npm
+
 ```sh
 npm i -S seng-boilerplate
 ```
 
-Or grab one of the following files from the `/dist/` folder for manual use:
+### manual
 
-- **umd** (bundled with webpack)
-- **amd** (bundled with webpack)
-- **commonjs2** (bundled with webpack, but why don't you use npm?)
-- **browser** (bundled with webpack, available as `window.SengBoilerplate`)
-- **system**
-- **es6**
+You can clone this repository and build the distribution files for use in
+the browser yourself, and grab one of the following files from the
+`/dist/` folder:
+
+```sh
+git clone git@github.com:mediamonks/seng-boilerplate.git
+cd seng-boilerplate
+npm i
+npm run build-dist
+```
+
+- **/dist/umd** (bundled with webpack)
+- **/dist/amd** (bundled with webpack)
+- **/dist/commonjs2** (bundled with webpack, but why don't you use npm?)
+- **/dist/browser** (bundled with webpack, available as `window.SengBoilerplate`)
+- **/dist/system**
+- **/dist/es6**
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "yuidoc": "yuidoc -o doc/yuidoc/ -t ./node_modules/yuidoc-mediamonks-theme -H ./node_modules/yuidoc-mediamonks-theme/helpers/helpers.js src/",
     "generate": "npm-run-all clean compile test-unit doc",
     "build": "npm-run-all clean compile",
-    "build-npm": "npm-run-all clean test typescript-npm"
+    "build-npm": "npm-run-all clean test typescript-npm",
+    "build-dist": "npm-run-all clean typescript-system typescript-es6 webpack-dist"
   },
   "pre-commit": [
     "validate"


### PR DESCRIPTION
As discussed in #11 we want to exclude the `/dist` folder from git, and
supply it in another way. Because the packages are not publicly
announced yet, and we provide a way in the readme to generate those
dist files, we already take the first step.

re #11