### PR TITLE
Fix the npm clean script for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check-coverage": "istanbul check-coverage --statement 1 --branches 1 --functions 1 --lines 1",
     "validate-webpack": "webpack-validator config/webpack.config.js",
     "lint": "tslint -c tslint.json src/**/*.ts",
-    "clean": "rimraf dist lib index.js index.d.ts coverage 'seng-*.@(zip|tar.gz)'",
+    "clean": "rimraf dist lib index.js index.d.ts coverage \"seng-*.@(zip|tar.gz)\"",
     "compile": "npm-run-all typescript-npm typescript-system typescript-es6 webpack-dist",
     "typescript-npm": "tsc -p ./ -d",
     "typescript-system": "tsc -p ./ -m system --outFile ./dist/seng-boilerplate-system.js",


### PR DESCRIPTION
Windows was breaking up the commands when it was not in double
quotes. Fixes #26