### PR TITLE
Fix typescript compiler input files

### DIFF
--- a/config/tsconfig.webpack.json
+++ b/config/tsconfig.webpack.json
@@ -10,7 +10,8 @@
     "removeComments": false,
     "noEmitHelpers": true,
     "sourceMap": false,
-    "inlineSourceMap": true
+    "inlineSourceMap": false,
+    "outDir": "./"
   },
   "files": [
     "typings/index.d.ts"

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = function()
 					exclude: /node_modules/,
 					loader: 'awesome-typescript-loader',
 					query: {
-						tsconfig: 'tsconfig.json'
+						tsconfig: 'config/tsconfig.webpack.json'
 					}
 				}
 			]


### PR DESCRIPTION
Create a tsconfig.webpack.json file which we will use for compiling typescript from webpack. This config will be the same as the default tsconfig.json, but we will not include the `src/index.ts` entry file. Our typescript loader in webpack will pass the input file to the compiler for us.

In the tsconfig.test.json, use the same files array as tsconfig.webpack.json. This will also solve some of the globbing issues we have with awesome-typescript-loader. Fixes #26