### PR TITLE
Remove the noEmitHelpers from tsconfig.json

### DIFF
--- a/config/tsconfig.test.json
+++ b/config/tsconfig.test.json
@@ -8,7 +8,6 @@
     "preserveConstEnums": true,
     "noImplicitAny": false,
     "removeComments": false,
-    "noEmitHelpers": true,
     "sourceMap": false,
     "inlineSourceMap": true
   },

--- a/config/tsconfig.webpack.json
+++ b/config/tsconfig.webpack.json
@@ -8,7 +8,6 @@
     "preserveConstEnums": true,
     "noImplicitAny": false,
     "removeComments": false,
-    "noEmitHelpers": true,
     "sourceMap": false,
     "inlineSourceMap": false,
     "outDir": "./"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "preserveConstEnums": true,
     "noImplicitAny": false,
     "removeComments": false,
-    "noEmitHelpers": true,
     "sourceMap": false,
     "inlineSourceMap": false,
     "outDir": "./"


### PR DESCRIPTION
The noEmitHelpers will make our bundle size smaller when used in combination with the ts-helpers module from npm. However, we cannot use this mechanism in builds where we output a JS file per JS
module. Until we have a way to include ts-helpers conditionally in single-file output builds, we have to remove this option.

See #29 