### PR TITLE
Move karma.conf.js to root of repo

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,9 +6,6 @@ module.exports = function(config)
 {
 	config.set({
 
-		// base path that will be used to resolve all patterns (eg. files, exclude)
-		basePath: '../',
-
 		// List of test frameworks we will use. Most of them are provided by separate packages (adapters).
 		// available frameworks: https://npmjs.org/browse/keyword/karma-adapter
 		frameworks: ['mocha', 'chai', 'source-map-support'],
@@ -34,7 +31,7 @@ module.exports = function(config)
 			]
 		},
 
-		webpack: require('./webpack.config.test')(),
+		webpack: require('./config/webpack.config.test')(),
 
 		// Make dev server silent.
 		webpackServer: { noInfo: true },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "typings": "typings install",
     "test": "npm run validate",
     "validate": "npm-run-all -p validate-webpack lint test-unit -s check-coverage",
-    "test-unit": "karma start config/karma.conf.js --single-run --browsers PhantomJS",
+    "test-unit": "karma start karma.conf.js --single-run --browsers PhantomJS",
     "check-coverage": "istanbul check-coverage --statement 1 --branches 1 --functions 1 --lines 1",
     "validate-webpack": "webpack-validator config/webpack.config.js",
     "lint": "tslint -c tslint.json src/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "typings": "typings install",
     "test": "npm run validate",
     "validate": "npm-run-all -p validate-webpack lint test-unit -s check-coverage",
-    "test-unit": "karma start karma.conf.js --single-run --browsers PhantomJS",
+    "test-unit": "karma start --single-run --browsers PhantomJS",
     "check-coverage": "istanbul check-coverage --statement 1 --branches 1 --functions 1 --lines 1",
     "validate-webpack": "webpack-validator config/webpack.config.js",
     "lint": "tslint -c tslint.json src/**/*.ts",


### PR DESCRIPTION
Move the karma.conf.js configuration file to the root of the repository, for better karma support in Webstorm. Webstorm can't currently handle karma configuration in a subfolder well.