### PR TITLE
Move typings to definition folder allowing local definitions as well.

### DIFF
--- a/config/tsconfig.test.json
+++ b/config/tsconfig.test.json
@@ -12,6 +12,6 @@
     "inlineSourceMap": true
   },
   "files": [
-    "typings/index.d.ts"
+    "definition/typings/index.d.ts"
   ]
 }

--- a/config/tsconfig.test.json
+++ b/config/tsconfig.test.json
@@ -12,6 +12,6 @@
     "inlineSourceMap": true
   },
   "files": [
-    "definition/typings/index.d.ts"
+    "definition/index.d.ts"
   ]
 }

--- a/config/tsconfig.webpack.json
+++ b/config/tsconfig.webpack.json
@@ -14,6 +14,6 @@
     "outDir": "./"
   },
   "files": [
-    "typings/index.d.ts"
+    "definition/typings/index.d.ts"
   ]
 }

--- a/config/tsconfig.webpack.json
+++ b/config/tsconfig.webpack.json
@@ -14,6 +14,6 @@
     "outDir": "./"
   },
   "files": [
-    "definition/typings/index.d.ts"
+    "definition/index.d.ts"
   ]
 }

--- a/definition/index.d.ts
+++ b/definition/index.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="typings/index.d.ts" />
+/// <reference path="local/index.d.ts" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,7 @@
     "outDir": "./"
   },
   "files": [
-    "./definition/typings/index.d.ts",
-    "./definition/local/index.d.ts",
+    "./definition/index.d.ts",
     "./src/index.ts",
     "./src/lib/Dummy.ts"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "outDir": "./"
   },
   "files": [
-    "./typings/index.d.ts",
+    "./definition/typings/index.d.ts",
+    "./definition/local/index.d.ts",
     "./src/index.ts",
     "./src/lib/Dummy.ts"
   ]

--- a/typings.json
+++ b/typings.json
@@ -1,4 +1,5 @@
 {
+  "resolution": "definition/typings",
   "globalDevDependencies": {
     "mocha": "registry:dt/mocha#2.2.5+20160619032855"
   },


### PR DESCRIPTION
typings will be installed in definition folder.
Local definitions should be stored in local folder, updating index.d.ts.